### PR TITLE
Fix supervisor.sock which doesn't play well with OverlayFS (now default ...

### DIFF
--- a/container-files/etc/supervisord.conf
+++ b/container-files/etc/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
-pidfile = /var/run/supervisord.pid
+pidfile = /run/supervisord.pid
 # It seems that it's not possible to swith this log to NONE (it creates NONE logfile)
 logfile = /data/logs/supervisord.log
 # Set loglevel=debug, only then all logs from child services are printed out
@@ -7,13 +7,18 @@ logfile = /data/logs/supervisord.log
 loglevel = debug
 
 # These two (unix_http_server, rpcinterface) are needed for supervisorctl to work
-[unix_http_server]
-file=/run/supervisor.sock
+[inet_http_server]
+port = :9111
+username = sv
+password = password
+
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///run/supervisor.sock
+serverurl = http://localhost:9111
+username = sv
+password = password
 
 [include]
 files = /etc/supervisor.d/*.conf


### PR DESCRIPTION
...on CoreOS)

This change configures inet http server for supervisorctl, instead of
unix http (using sockets). This is because OverlayFS and unix sockets
seem to not play well.